### PR TITLE
Move ping-home workflow logic into composite actions under packages/p…

### DIFF
--- a/.github/workflows/ping-home-app.yml
+++ b/.github/workflows/ping-home-app.yml
@@ -4,6 +4,7 @@ on:
       - "main"
     paths:
       - ".github/workflows/ping-home-app.yml"
+      - "packages/ping-home/actions/deploy/**"
       - "packages/ping-home/app/**"
 
 jobs:
@@ -15,25 +16,9 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
-      - uses: google-github-actions/auth@v3
-        id: auth
+      - uses: ./packages/ping-home/actions/deploy
         with:
           workload_identity_provider: ${{ secrets.GOOGLE_CLOUD_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GOOGLE_CLOUD_DEPLOY_SERVICE_ACCOUNT }}
-          token_format: access_token
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.GOOGLE_CLOUD_REGION }}-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: packages/ping-home/app
-          push: true
-          tags: ${{ secrets.GOOGLE_CLOUD_REGION }}-docker.pkg.dev/${{ steps.auth.outputs.project_id }}/lan-checker-repo/lan-checker:${{ github.sha }}
-      - uses: google-github-actions/deploy-cloudrun@v3
-        with:
-          service: home-lan-checker
-          region: ${{ secrets.GOOGLE_CLOUD_REGION }}
-          image: ${{ secrets.GOOGLE_CLOUD_REGION }}-docker.pkg.dev/${{ steps.auth.outputs.project_id }}/lan-checker-repo/lan-checker:${{ github.sha }}
+          deploy_service_account: ${{ secrets.GOOGLE_CLOUD_DEPLOY_SERVICE_ACCOUNT }}
+          google_cloud_region: ${{ secrets.GOOGLE_CLOUD_REGION }}
+          image_tag: ${{ github.sha }}

--- a/.github/workflows/ping-home-infra.yml
+++ b/.github/workflows/ping-home-infra.yml
@@ -4,6 +4,7 @@ on:
       - "main"
     paths:
       - ".github/workflows/ping-home-infra.yml"
+      - "packages/ping-home/actions/infra/**"
       - "packages/ping-home/terraform/**"
 
 jobs:
@@ -13,31 +14,15 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    defaults:
-      run:
-        working-directory: packages/ping-home/terraform
-    env:
-      TF_VAR_github_repo: ${{ github.repository }}
-      TF_VAR_google_project: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
-      TF_VAR_google_region: ${{ secrets.GOOGLE_CLOUD_REGION }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/create-github-app-token@v2
-        id: app-token
-        with:
-          app-id: ${{ vars.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      - uses: google-github-actions/auth@v3
+      - uses: ./packages/ping-home/actions/infra
         with:
           workload_identity_provider: ${{ secrets.GOOGLE_CLOUD_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GOOGLE_CLOUD_TERRAFORM_SERVICE_ACCOUNT }}
-      - uses: hashicorp/setup-terraform@v3
-      - run: terraform init -backend-config="bucket=${{ secrets.TERRAFORM_STATE_BUCKET_NAME }}"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-      - run: terraform plan -out=tfplan
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-      - run: terraform apply -auto-approve tfplan
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          terraform_service_account: ${{ secrets.GOOGLE_CLOUD_TERRAFORM_SERVICE_ACCOUNT }}
+          terraform_state_bucket: ${{ secrets.TERRAFORM_STATE_BUCKET_NAME }}
+          gh_app_id: ${{ vars.GH_APP_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          google_cloud_project: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
+          google_cloud_region: ${{ secrets.GOOGLE_CLOUD_REGION }}
+          github_repository: ${{ github.repository }}

--- a/packages/ping-home/actions/deploy/action.yml
+++ b/packages/ping-home/actions/deploy/action.yml
@@ -1,0 +1,46 @@
+name: Build and Deploy ping-home App
+description: Builds the Docker image and deploys it to Cloud Run using Workload Identity Federation.
+
+inputs:
+  workload_identity_provider:
+    description: Google Cloud Workload Identity Provider resource name
+    required: true
+  deploy_service_account:
+    description: Google Cloud service account email for deployment
+    required: true
+  google_cloud_region:
+    description: Google Cloud region
+    required: true
+  image_tag:
+    description: Docker image tag
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: google-github-actions/auth@v3
+      id: auth
+      with:
+        workload_identity_provider: ${{ inputs.workload_identity_provider }}
+        service_account: ${{ inputs.deploy_service_account }}
+        token_format: access_token
+
+    - uses: docker/setup-buildx-action@v3
+
+    - uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.google_cloud_region }}-docker.pkg.dev
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
+
+    - uses: docker/build-push-action@v6
+      with:
+        context: packages/ping-home/app
+        push: true
+        tags: ${{ inputs.google_cloud_region }}-docker.pkg.dev/${{ steps.auth.outputs.project_id }}/lan-checker-repo/lan-checker:${{ inputs.image_tag }}
+
+    - uses: google-github-actions/deploy-cloudrun@v3
+      with:
+        service: home-lan-checker
+        region: ${{ inputs.google_cloud_region }}
+        image: ${{ inputs.google_cloud_region }}-docker.pkg.dev/${{ steps.auth.outputs.project_id }}/lan-checker-repo/lan-checker:${{ inputs.image_tag }}

--- a/packages/ping-home/actions/infra/action.yml
+++ b/packages/ping-home/actions/infra/action.yml
@@ -1,0 +1,74 @@
+name: Plan and Apply ping-home Terraform
+description: Runs Terraform init, plan, and apply for the ping-home infrastructure.
+
+inputs:
+  workload_identity_provider:
+    description: Google Cloud Workload Identity Provider resource name
+    required: true
+  terraform_service_account:
+    description: Google Cloud service account email for Terraform
+    required: true
+  terraform_state_bucket:
+    description: GCS bucket name for Terraform remote state
+    required: true
+  gh_app_id:
+    description: GitHub App ID for creating tokens
+    required: true
+  gh_app_private_key:
+    description: GitHub App private key PEM
+    required: true
+  google_cloud_project:
+    description: Google Cloud project ID
+    required: true
+  google_cloud_region:
+    description: Google Cloud region
+    required: true
+  github_repository:
+    description: Repository in owner/repo format
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/create-github-app-token@v2
+      id: app-token
+      with:
+        app-id: ${{ inputs.gh_app_id }}
+        private-key: ${{ inputs.gh_app_private_key }}
+
+    - uses: google-github-actions/auth@v3
+      with:
+        workload_identity_provider: ${{ inputs.workload_identity_provider }}
+        service_account: ${{ inputs.terraform_service_account }}
+
+    - uses: hashicorp/setup-terraform@v3
+
+    - name: Terraform init
+      shell: bash
+      working-directory: packages/ping-home/terraform
+      env:
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        TF_VAR_github_repo: ${{ inputs.github_repository }}
+        TF_VAR_google_project: ${{ inputs.google_cloud_project }}
+        TF_VAR_google_region: ${{ inputs.google_cloud_region }}
+      run: terraform init -backend-config="bucket=${{ inputs.terraform_state_bucket }}"
+
+    - name: Terraform plan
+      shell: bash
+      working-directory: packages/ping-home/terraform
+      env:
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        TF_VAR_github_repo: ${{ inputs.github_repository }}
+        TF_VAR_google_project: ${{ inputs.google_cloud_project }}
+        TF_VAR_google_region: ${{ inputs.google_cloud_region }}
+      run: terraform plan -out=tfplan
+
+    - name: Terraform apply
+      shell: bash
+      working-directory: packages/ping-home/terraform
+      env:
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        TF_VAR_github_repo: ${{ inputs.github_repository }}
+        TF_VAR_google_project: ${{ inputs.google_cloud_project }}
+        TF_VAR_google_region: ${{ inputs.google_cloud_region }}
+      run: terraform apply -auto-approve tfplan


### PR DESCRIPTION
…ing-home

Colocates the build/deploy and Terraform step logic with the package they serve, using GitHub composite actions (packages/ping-home/actions/deploy and packages/ping-home/actions/infra). The .github/workflows/ files become thin wrappers that only own triggers, environment gates, and permissions.

https://claude.ai/code/session_01XN9viepeRU2fcE64sbhgUC