### PR TITLE
Increase SuspiciousDnsSpike alert threshold to reduce noise

### DIFF
--- a/systems/pi/prometheus/rules.yml
+++ b/systems/pi/prometheus/rules.yml
@@ -137,13 +137,13 @@ groups:
           description: "Over 50% of DNS queries are being blocked - possible misconfiguration or malware"
 
       - alert: SuspiciousDnsSpike
-        expr: rate(blocky_query_total[5m]) > 10 * avg_over_time(rate(blocky_query_total[5m])[1d:5m])
-        for: 5m
+        expr: rate(blocky_query_total[5m]) > 20 * avg_over_time(rate(blocky_query_total[5m])[1d:5m])
+        for: 15m
         labels:
           severity: warning
         annotations:
           summary: "Unusual DNS query spike"
-          description: "DNS queries are 10x higher than daily average - possible malware or DoS"
+          description: "DNS queries are 20x higher than daily average - possible malware or DoS"
 
       - alert: HighOutboundConnections
         expr: node_netstat_Tcp_CurrEstab > 500


### PR DESCRIPTION
Raise the multiplier from 10x to 20x and extend the required duration
from 5m to 15m. This reduces false positives while still catching
genuine spikes that are clearly anomalous.

https://claude.ai/code/session_01UbaLcZm24vknfooDm7vvsq