### PR TITLE
Add portable home config for zero-commit machine setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ My personal computing configuration that I wish to sync between machines.
 1. Create macOS configuration with `nh darwin switch github:carlthome/dotfiles`
 1. Create user configuration with `nh home switch github:carlthome/dotfiles`
 
+### New machine (portable setup)
+
+For machines where your username or work email differs from an existing config, use the portable home configuration. It auto-detects your username and home directory from the environment, and reads your work email from a local file that isn't tracked by git.
+
+```bash
+# Optionally set a work email (skip to use personal email as default):
+mkdir -p ~/.config/dotfiles
+echo "you@work.com" > ~/.config/dotfiles/git-email
+
+# Apply the portable home configuration:
+home-manager switch --flake github:carlthome/dotfiles#portable --impure
+```
+
+Auto-upgrade is enabled and will re-read the local email file on each run, so no git commits are needed when you change jobs.
+
 ## Usage
 
 Run packages by `nix run dotfiles#<name>` where `<name>` is the package name.

--- a/homes/portable/default.nix
+++ b/homes/portable/default.nix
@@ -1,0 +1,41 @@
+{
+  home-manager,
+  nixpkgs,
+  nix-index-database,
+  system,
+  self,
+  nixvim,
+  ...
+}@inputs:
+
+home-manager.lib.homeManagerConfiguration {
+  extraSpecialArgs = inputs;
+  pkgs = import nixpkgs {
+    inherit system;
+    overlays = [
+      self.overlays.nixpkgs-unstable
+    ];
+  };
+  modules = [
+    ./home.nix
+    nix-index-database.homeModules.nix-index
+    nixvim.homeModules.nixvim
+    self.homeModules.${system}
+    self.homeModules.auto-audit
+    self.homeModules.auto-upgrade
+    self.homeModules.emacs
+    self.homeModules.fzf
+    self.homeModules.git
+    self.homeModules.git-refresh
+    self.homeModules.github
+    self.homeModules.helix
+    self.homeModules.home
+    self.homeModules.kitty
+    self.homeModules.neovim
+    self.homeModules.tmux
+    self.homeModules.vim
+    self.homeModules.vscode
+    self.homeModules.direnv
+    self.homeModules.macos-spotlight-apps
+  ];
+}

--- a/homes/portable/home.nix
+++ b/homes/portable/home.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  username = builtins.getEnv "USER";
+  homeDirectory = builtins.getEnv "HOME";
+
+  # Read work email from ~/.config/dotfiles/git-email if it exists,
+  # then fall back to GIT_EMAIL env var, then personal email.
+  gitEmailFile = "${homeDirectory}/.config/dotfiles/git-email";
+  gitEmail =
+    if builtins.pathExists gitEmailFile then
+      builtins.replaceStrings [ "\n" "\r" ] [ "" "" ] (builtins.readFile gitEmailFile)
+    else
+      let
+        env = builtins.getEnv "GIT_EMAIL";
+      in
+      if env != "" then env else "carlthome@gmail.com";
+in
+{
+  home.username = username;
+  home.homeDirectory = homeDirectory;
+  programs.git.settings.user.name = "Carl Thomé";
+  programs.git.settings.user.email = gitEmail;
+  services.auto-upgrade = {
+    enable = true;
+    flake = "github:carlthome/dotfiles#portable";
+    impure = true;
+  };
+}

--- a/homes/portable/home.nix
+++ b/homes/portable/home.nix
@@ -5,20 +5,26 @@
   ...
 }:
 let
-  username = builtins.getEnv "USER";
-  homeDirectory = builtins.getEnv "HOME";
+  # builtins.getEnv returns "" in pure/CI mode; provide valid fallbacks so the
+  # config builds without --impure. On a real machine, pass --impure and these
+  # will reflect the actual user.
+  username = let u = builtins.getEnv "USER"; in if u != "" then u else "user";
+  homeEnv = builtins.getEnv "HOME";
+  homeDirectory = if homeEnv != "" then homeEnv else "/home/${username}";
 
-  # Read work email from ~/.config/dotfiles/git-email if it exists,
-  # then fall back to GIT_EMAIL env var, then personal email.
+  # Guard pathExists behind homeEnv check: Nix && is lazy, so pathExists is
+  # never called in pure mode (where homeEnv == ""), avoiding restricted-access errors.
   gitEmailFile = "${homeDirectory}/.config/dotfiles/git-email";
   gitEmail =
-    if builtins.pathExists gitEmailFile then
-      builtins.replaceStrings [ "\n" "\r" ] [ "" "" ] (builtins.readFile gitEmailFile)
-    else
-      let
-        env = builtins.getEnv "GIT_EMAIL";
-      in
-      if env != "" then env else "carlthome@gmail.com";
+    let
+      fromFile =
+        if homeEnv != "" && builtins.pathExists gitEmailFile then
+          builtins.replaceStrings [ "\n" "\r" ] [ "" "" ] (builtins.readFile gitEmailFile)
+        else
+          "";
+      fromEnv = builtins.getEnv "GIT_EMAIL";
+    in
+    if fromFile != "" then fromFile else if fromEnv != "" then fromEnv else "carlthome@gmail.com";
 in
 {
   home.username = username;

--- a/modules/home-manager/auto-upgrade/default.nix
+++ b/modules/home-manager/auto-upgrade/default.nix
@@ -14,7 +14,7 @@ let
     text = ''
       echo "Starting Home Manager upgrade at $(date)"
       start=$(date +%s)
-      home-manager switch --print-build-logs --refresh --flake ${cfg.flake}
+      home-manager switch --print-build-logs --refresh --flake ${cfg.flake}${lib.optionalString cfg.impure " --impure"}
       echo "Home Manager upgrade completed at $(date) (elapsed: $(($(date +%s) - start))s)"
     '';
     runtimeInputs = with pkgs; [
@@ -73,6 +73,12 @@ in
       flake = lib.mkOption {
         type = lib.types.str;
         description = "Flake URI to use for upgrades";
+      };
+
+      impure = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Pass --impure to home-manager switch (needed for configs that read from the environment)";
       };
     };
   };


### PR DESCRIPTION
## Summary

- Adds `homes/portable/` — a home-manager config that auto-detects `$USER` and `$HOME` at eval time so it works on any machine regardless of username
- Work email is read from `~/.config/dotfiles/git-email` (a local file, not tracked by git), falling back to `GIT_EMAIL` env var, then personal email
- Adds an `impure` option to the auto-upgrade module so daily syncs continue to work without any committed credentials
- Updates README with a "New machine (portable setup)" section

## How it solves the problem

When you start at a new job, instead of creating a new `homes/<username>/` directory and committing it, you just run two commands on the new machine:

```bash
# Once per machine — store your work email locally (not in git):
mkdir -p ~/.config/dotfiles && echo "you@work.com" > ~/.config/dotfiles/git-email

# Apply the portable config (works for any username/hostname):
home-manager switch --flake github:carlthome/dotfiles#portable --impure
```

Auto-upgrade is enabled in the portable config and passes `--impure` on each run, so it re-reads `~/.config/dotfiles/git-email` daily without any stored per-machine config in the repo.

## Test plan

- [ ] Verify `homes/portable/` is picked up by `homes/default.nix` (it scans for directories dynamically, so no changes needed there)
- [ ] Test on a machine where `$USER` differs from `carl`/`carlthome`
- [ ] Verify auto-upgrade service command includes `--impure` when `impure = true`

https://claude.ai/code/session_01TByFmdLV4DEF8MKTKn1jPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01TByFmdLV4DEF8MKTKn1jPK)_