### PR TITLE
Add Tailscale auth key rotation

### DIFF
--- a/packages/ping-home/README.md
+++ b/packages/ping-home/README.md
@@ -14,6 +14,33 @@ Prerequisites: `gcloud auth login` and `gh auth login`.
 
 2. Push to the repository to trigger the GitHub Actions deployment workflow.
 
+## Rotate the Tailscale auth key
+
+Tailscale auth keys expire after at most 90 days. When the key expires,
+`home-lan-checker` fails to start with an error such as:
+
+```text
+backend error: invalid key: API key does not exist
+```
+
+Generate a new **reusable, ephemeral** auth key with the `tag:monitor` tag in
+the Tailscale admin console. If Tailnet Lock is enabled, sign the key from a
+trusted signing node before continuing:
+
+```sh
+tailscale lock sign <auth-key>
+```
+
+Then add the key as a new version of the existing GCP secret:
+
+```sh
+./rotate-tailscale-auth-key.sh
+```
+
+The key is entered without echo and is sent directly to Secret Manager. It is
+not passed as a command-line argument or stored in the repository. Failed Cloud
+Run instances will read the new `latest` secret version when they restart.
+
 ## Tailnet Lock
 
 If tailnet lock is enabled, the auth key must be pre-signed so ephemeral containers are automatically trusted. From a trusted signing node (e.g., pi):

--- a/packages/ping-home/README.md
+++ b/packages/ping-home/README.md
@@ -34,7 +34,7 @@ tailscale lock sign <auth-key>
 Then add the key as a new version of the existing GCP secret:
 
 ```sh
-./rotate-tailscale-auth-key.sh
+bash ./rotate-tailscale-auth-key.sh
 ```
 
 The key is entered without echo and is sent directly to Secret Manager. It is

--- a/packages/ping-home/app/start.sh
+++ b/packages/ping-home/app/start.sh
@@ -1,17 +1,34 @@
 #!/bin/bash
+set -euo pipefail
 
 # Start Tailscale in userspace networking mode with a SOCKS5 server.
 tailscaled --tun=userspace-networking --state=mem: --socks5-server="${TS_SOCKS5_SERVER}" 2>&1 | grep -i -E "error|warn|fatal" &
 sleep 2
 
 # Append Cloud Run revision to hostname.
-if [ -n "${K_REVISION}" ]; then
+if [ -n "${K_REVISION:-}" ]; then
 	TS_HOSTNAME="${TS_HOSTNAME}-${K_REVISION}"
 fi
 
 # Authenticate to Tailscale network with the provided auth key.
-TS_AUTHKEY=$(cat /secrets/tailscale-auth-key)
-tailscale up --authkey="${TS_AUTHKEY}" --hostname="${TS_HOSTNAME}" --advertise-tags=tag:monitor 2>&1 | grep -i -E "error|warn|fatal"
+auth_key_file=${TS_AUTHKEY_FILE:-/secrets/tailscale-auth-key}
+if [ ! -s "${auth_key_file}" ]; then
+	echo "ERROR: Tailscale auth key secret is missing or empty." >&2
+	exit 1
+fi
+
+TS_AUTHKEY=$(<"${auth_key_file}")
+if ! tailscale_output=$(
+	tailscale up \
+		--authkey="${TS_AUTHKEY}" \
+		--hostname="${TS_HOSTNAME}" \
+		--advertise-tags=tag:monitor 2>&1
+); then
+	echo "ERROR: Tailscale authentication failed. The tailscale-auth-key secret may be expired or revoked." >&2
+	printf '%s\n' "${tailscale_output}" >&2
+	exit 1
+fi
+unset TS_AUTHKEY
 
 # Verify we got an IP.
 tailscale ip -4 || exit 1

--- a/packages/ping-home/rotate-tailscale-auth-key.sh
+++ b/packages/ping-home/rotate-tailscale-auth-key.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Add a new Tailscale auth key version to GCP Secret Manager.
+set -euo pipefail
+
+secret_name=tailscale-auth-key
+project=${GOOGLE_CLOUD_PROJECT:-${CLOUDSDK_CORE_PROJECT:-}}
+
+if ! command -v gcloud >/dev/null 2>&1; then
+	echo "Error: gcloud is required." >&2
+	exit 1
+fi
+
+if [ -z "${project}" ]; then
+	read -rp "GCP Project ID: " project
+fi
+
+if [ -z "${project}" ]; then
+	echo "Error: GCP project ID cannot be empty." >&2
+	exit 1
+fi
+
+read -rsp "New reusable, ephemeral Tailscale auth key: " auth_key
+echo
+
+if [[ "${auth_key}" != tskey-auth-* ]]; then
+	echo "Error: value does not look like a Tailscale auth key." >&2
+	exit 1
+fi
+
+printf '%s' "${auth_key}" |
+	gcloud secrets versions add "${secret_name}" \
+		--project="${project}" \
+		--data-file=- >/dev/null
+unset auth_key
+
+echo "✓ Added a new ${secret_name} version."
+echo "New Cloud Run instances will use it automatically."


### PR DESCRIPTION
## Summary

- add a safe helper for rotating the `tailscale-auth-key` Secret Manager value
- fail fast with a clear startup error when the mounted key is missing, expired, or revoked
- document the 90-day Tailscale auth-key limit, `tag:monitor`, and Tailnet Lock signing

## Root cause

`home-lan-checker` used a static Tailscale auth key created months ago. Tailscale auth keys expire after at most 90 days, while the existing setup helper deliberately skipped secrets that already had a value. Cloud Run therefore kept trying the expired key and logged `backend error: invalid key: API key does not exist`.

## Validation

- `bash -n` for both shell scripts
- isolated successful and rejected-key tests for the rotation helper
- isolated reproduction of the exact Tailscale authentication error path
- `uv run --frozen pytest -q`: 3 passed
- `git diff --check`

## Operational follow-up

Generate a new reusable, ephemeral `tag:monitor` auth key, sign it if Tailnet Lock is enabled, and run:

```sh
bash ./packages/ping-home/rotate-tailscale-auth-key.sh
```

The secret itself must not be posted in this PR.